### PR TITLE
Switch to sassc

### DIFF
--- a/fomantic-ui-sass.gemspec
+++ b/fomantic-ui-sass.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'autoprefixer-rails'
   spec.add_runtime_dependency 'rails', '>= 3.2.0'
-  spec.add_runtime_dependency 'sass', '>= 3.2'
-  spec.add_runtime_dependency 'sass-rails', '>= 3.2'
+  spec.add_runtime_dependency 'sassc', '>= 2.2'
+  spec.add_runtime_dependency 'sassc-rails', '>= 2.1'
   spec.add_runtime_dependency 'sprockets-rails', '>= 2.1.3'
 
   spec.add_development_dependency 'bundler', '>= 1.3'

--- a/lib/fomantic-ui-sass.rb
+++ b/lib/fomantic-ui-sass.rb
@@ -51,8 +51,8 @@ module Fomantic
         end
 
         def configure_sass
-          require 'sass'
-          ::Sass.load_paths << stylesheets_path
+          require 'sassc'
+          ::SassC.load_paths << stylesheets_path
         end
       end
     end


### PR DESCRIPTION
As you are probably aware, [ruby sass is deprecated](http://sass.logdown.com/posts/7828841). This switches the `sass` and `sass-rails` dependencies to their `sassc` counterparts, and uses the `SassC` module instead of `Sass`.

In theory, _it just works_. At least my limited testing did not reveal issues 😃 .

ℹ️ I also added an empty `app/assets/config/manifest.js` in the dummy app for `rake spec` to pass; this is required by Sprockets 4.0.