### PR TITLE
gemspec: Depend on railties rather that rails

### DIFF
--- a/fomantic-ui-sass.gemspec
+++ b/fomantic-ui-sass.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'autoprefixer-rails'
-  spec.add_runtime_dependency 'rails', '>= 3.2.0'
+  spec.add_runtime_dependency 'railties', '>= 3.2.0'
   spec.add_runtime_dependency 'sassc', '>= 2.2'
   spec.add_runtime_dependency 'sassc-rails', '>= 2.1'
   spec.add_runtime_dependency 'sprockets-rails', '>= 2.1.3'


### PR DESCRIPTION
Hey,

just wanted to start a "lightweight" new rails app which doesn't `require rails/rails` as I don't need all the fancy stuff like activemailbox, activestorage, etc so I dropped all the unnecessary stuff and..... found out that you actually require rails/rails as dependency for this engine which is a pretty fat dependency tail and not actually necessary.

`railties` should be more than sufficient and you could probably even work without it but since it's a rails engine you need that one anyways at some point.